### PR TITLE
(maint) Allow git to use long paths in GitHub Actions

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   daily_unit_tests_with_nightly_puppet_gem:
-    name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }} 
+    name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
         os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
@@ -50,6 +50,7 @@ jobs:
 
       - name: Prepare testing environment with bundler
         run: |
+          git config --global core.longpaths true
           bundle config set system 'true'
           ${{ matrix.env_set_cmd }}PUPPET_GEM_VERSION=$(ruby -e 'puts /puppet\s+\((.+)\)/.match(`gem list -eld puppet`)[1]')
           bundle update --jobs 4 --retry 3

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -28,7 +28,9 @@ jobs:
           ruby-version: ${{ env.ruby_version }}
 
       - name: Prepare testing environment with bundler
-        run: bundle update --jobs 4 --retry 3
+        run: |
+          git config --global core.longpaths true
+          bundle update --jobs 4 --retry 3
 
       - name: Run commits check
         run: bundle exec rake commits

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Prepare testing environment with bundler
         run: |
+          git config --global core.longpaths true
           bundle config set system 'true'
           ${{ matrix.env_set_cmd }}PUPPET_GEM_VERSION=$(ruby -e 'puts /puppet\s+\((.+)\)/.match(`gem list -eld puppet`)[1]')
           bundle update --jobs 4 --retry 3

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   unit_tests_with_released_puppet_gem:
-    name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }} 
+    name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
         os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
@@ -41,6 +41,7 @@ jobs:
 
       - name: Prepare testing environment with bundler
         run: |
+          git config --global core.longpaths true
           bundle config set system 'true'
           bundle update --jobs 4 --retry 3
 


### PR DESCRIPTION
Due to unknown environment changes in GitHub Actions runners, we encountered the following error:
`fatal: cannot create directory at 'spec/vcr/GitHubChangelogGenerator_OctoFetcher/_fetch_closed_issues_and_pr/when_API_call_is_valid/returns_pull_request_with_proper_key': Filename too long`

As seen [here](https://github.com/puppetlabs/puppetlabs-cron_core/runs/1378175681?check_suite_focus=true), it was happening when trying to clone https://github.com/skywinder/github-changelog-generator, which indeed has very long paths in [spec folder](https://github.com/skywinder/gitlab-changelog-generator/tree/master/spec/vcr/GitHubChangelogGenerator_OctoFetcher/_fetch_closed_issues_and_pr/when_API_call_is_valid/returns_pull_request_with_proper_key).

This commit allows git to use long paths in our GitHub Actions workflows by running:
`git config --global core.longpaths true`