### PR TITLE
(MODULES-10953) Update metadata.json and pdk version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ end
 
 group :release do
   gem "puppet-blacksmith", '~> 3.4',                                             require: false
-  gem "pdk",                                                                     platforms: [:ruby]
+  gem "pdk", '~> 2.0',                                                           platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/metadata.json
+++ b/metadata.json
@@ -15,16 +15,13 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "Solaris",
-      "operatingsystemrelease": [
-        "11"
-      ]
+      "operatingsystem": "Solaris"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.14.0",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ default_facts.each do |fact, value|
 end
 
 RSpec.configure do |c|
+  c.mock_with :rspec
   c.default_facts = default_facts
   c.before :each do
     # set to strictest setting for testing

--- a/spec/unit/provider/zone/solaris_spec.rb
+++ b/spec/unit/provider/zone/solaris_spec.rb
@@ -7,19 +7,19 @@ describe Puppet::Type.type(:zone).provider(:solaris) do
 
   context '#configure' do
     it 'adds the create args to the create str' do
-      resource.stubs(:properties).returns([])
+      allow(resource).to receive(:properties).and_return([])
       resource[:create_args] = 'create_args'
-      provider.expects(:setconfig).with('create -b create_args')
+      expect(provider).to receive(:setconfig).with('create -b create_args')
       provider.configure
     end
     it 'adds the create args to the create str with properties' do
-      iptype = stub 'property'
-      iptype.stubs(:name).with.returns(:iptype)
-      iptype.stubs(:safe_insync?).with(iptype).returns(false)
-      provider.stubs(:properties).returns(iptype: iptype)
-      resource.stubs(:properties).with.returns([iptype])
+      iptype = instance_double 'Puppet::Property'
+      allow(iptype).to receive(:name).and_return(:iptype)
+      allow(iptype).to receive(:safe_insync?).with(iptype).and_return(false)
+      allow(provider).to receive(:properties).and_return(iptype: iptype)
+      allow(resource).to receive(:properties).and_return([iptype])
       resource[:create_args] = 'create_args'
-      provider.expects(:setconfig).with("create -b create_args\nset ip-type=shared")
+      expect(provider).to receive(:setconfig).with("create -b create_args\nset ip-type=shared")
       provider.configure
     end
   end
@@ -27,13 +27,13 @@ describe Puppet::Type.type(:zone).provider(:solaris) do
   context '#install' do
     context 'clone' do
       it 'calls zoneadm' do
-        provider.expects(:zoneadm).with(:install)
+        expect(provider).to receive(:zoneadm).with(:install)
         provider.install
       end
 
       it "with the resource's clone attribute" do
         resource[:clone] = :clone_argument
-        provider.expects(:zoneadm).with(:clone, :clone_argument)
+        expect(provider).to receive(:zoneadm).with(:clone, :clone_argument)
         provider.install
       end
     end
@@ -41,24 +41,24 @@ describe Puppet::Type.type(:zone).provider(:solaris) do
     context 'not clone' do
       it 'justs install if there are no install args' do
         # there is a nil check in type.rb:[]= so we cannot directly set nil.
-        resource.stubs(:[]).with(:clone).returns(nil)
-        resource.stubs(:[]).with(:install_args).returns(nil)
-        provider.expects(:zoneadm).with(:install)
+        allow(resource).to receive(:[]).with(:clone).and_return(nil)
+        allow(resource).to receive(:[]).with(:install_args).and_return(nil)
+        expect(provider).to receive(:zoneadm).with(:install)
         provider.install
       end
 
       it 'adds the install args to the command if they exist' do
         # there is a nil check in type.rb:[]= so we cannot directly set nil.
-        resource.stubs(:[]).with(:clone).returns(nil)
-        resource.stubs(:[]).with(:install_args).returns('install args')
-        provider.expects(:zoneadm).with(:install, ['install', 'args'])
+        allow(resource).to receive(:[]).with(:clone).and_return(nil)
+        allow(resource).to receive(:[]).with(:install_args).and_return('install args')
+        expect(provider).to receive(:zoneadm).with(:install, ['install', 'args'])
         provider.install
       end
     end
   end
   context '#instances' do
     it 'lists the instances correctly' do
-      described_class.expects(:adm).with(:list, '-cp').returns('0:dummy:running:/::native:shared')
+      expect(described_class).to receive(:adm).with(:list, '-cp').and_return('0:dummy:running:/::native:shared')
       instances = described_class.instances.map { |p| { name: p.get(:name), ensure: p.get(:ensure) } }
       expect(instances.size).to eq(1)
       expect(instances[0]).to eq(name: 'dummy',
@@ -67,15 +67,16 @@ describe Puppet::Type.type(:zone).provider(:solaris) do
   end
   context '#setconfig' do
     it 'correctlies set configuration' do
-      provider.expects(:command).with(:cfg).returns('/usr/sbin/zonecfg')
-      provider.expects(:exec_cmd).with(input: "set zonepath=/\ncommit\nexit", cmd: '/usr/sbin/zonecfg -z dummy -f -').returns(out: '', exit: 0)
+      expect(provider).to receive(:command).with(:cfg).and_return('/usr/sbin/zonecfg')
+      expect(provider).to receive(:exec_cmd).with(input: "set zonepath=/\ncommit\nexit", cmd: '/usr/sbin/zonecfg -z dummy -f -').and_return(out: '', exit: 0)
       provider.setconfig("set zonepath=\/")
       provider.flush
     end
 
     it "correctlies warn on 'not allowed'" do
-      provider.expects(:command).with(:cfg).returns('/usr/sbin/zonecfg')
-      provider.expects(:exec_cmd).with(input: "set zonepath=/\ncommit\nexit", cmd: '/usr/sbin/zonecfg -z dummy -f -').returns(out: "Zone z2 already installed; set zonepath not allowed.\n", exit: 0)
+      expect(provider).to receive(:command).with(:cfg).and_return('/usr/sbin/zonecfg')
+      expect(provider).to receive(:exec_cmd).with(input: "set zonepath=/\ncommit\nexit", cmd: '/usr/sbin/zonecfg -z dummy -f -')
+                                            .and_return(out: "Zone z2 already installed; set zonepath not allowed.\n", exit: 0)
       provider.setconfig("set zonepath=\/")
       expect {
         provider.flush
@@ -105,7 +106,7 @@ net:
         defrouter not specified
       EOF
       it 'correctlies parse zone info' do
-        provider.expects(:zonecfg).with(:info).returns(zone_info)
+        expect(provider).to receive(:zonecfg).with(:info).and_return(zone_info)
         expect(provider.getconfig).to eq(:brand => 'native',
                                          :autoboot => 'true',
                                          :"ip-type" => 'shared',
@@ -134,7 +135,7 @@ net:
         defrouter not specified
       EOF
       it 'correctlies parse zone info' do
-        provider.expects(:zonecfg).with(:info).returns(zone_info)
+        expect(provider).to receive(:zonecfg).with(:info).and_return(zone_info)
         expect(provider.getconfig).to eq(:brand => 'native',
                                          :autoboot => 'true',
                                          :"ip-type" => 'exclusive',
@@ -149,30 +150,30 @@ net:
           physical: net1'
         EOF
 
-        provider.expects(:zonecfg).with(:info).returns(erroneous_zone_info)
-        provider.expects('err').with("Ignoring '          physical: net1''")
+        expect(provider).to receive(:zonecfg).with(:info).and_return(erroneous_zone_info)
+        expect(provider).to receive('err').with("Ignoring '          physical: net1''")
         provider.getconfig
       end
 
       it 'produces a debugging message with provider context when given an unrecognized config' do
         unrecognized_zone_info = 'dummy'
-        provider.expects(:zonecfg).with(:info).returns(unrecognized_zone_info)
-        provider.expects('debug').with("Ignoring zone output 'dummy'")
+        expect(provider).to receive(:zonecfg).with(:info).and_return(unrecognized_zone_info)
+        expect(provider).to receive('debug').with("Ignoring zone output 'dummy'")
         provider.getconfig
       end
     end
   end
   context '#flush' do
     it 'correctlies execute pending commands' do
-      provider.expects(:command).with(:cfg).returns('/usr/sbin/zonecfg')
-      provider.expects(:exec_cmd).with(input: "set iptype=shared\ncommit\nexit", cmd: '/usr/sbin/zonecfg -z dummy -f -').returns(out: '', exit: 0)
+      expect(provider).to receive(:command).with(:cfg).and_return('/usr/sbin/zonecfg')
+      expect(provider).to receive(:exec_cmd).with(input: "set iptype=shared\ncommit\nexit", cmd: '/usr/sbin/zonecfg -z dummy -f -').and_return(out: '', exit: 0)
       provider.setconfig('set iptype=shared')
       provider.flush
     end
 
     it 'correctlies raise error on failure' do
-      provider.expects(:command).with(:cfg).returns('/usr/sbin/zonecfg')
-      provider.expects(:exec_cmd).with(input: "set iptype=shared\ncommit\nexit", cmd: '/usr/sbin/zonecfg -z dummy -f -').returns(out: '', exit: 1)
+      expect(provider).to receive(:command).with(:cfg).and_return('/usr/sbin/zonecfg')
+      expect(provider).to receive(:exec_cmd).with(input: "set iptype=shared\ncommit\nexit", cmd: '/usr/sbin/zonecfg -z dummy -f -').and_return(out: '', exit: 1)
       provider.setconfig('set iptype=shared')
       expect {
         provider.flush
@@ -183,15 +184,15 @@ net:
     it 'does not require path if sysidcfg is specified' do
       resource[:path] = '/mypath'
       resource[:sysidcfg] = 'dummy'
-      Puppet::FileSystem.stubs(:exist?).with('/mypath/root/etc/sysidcfg').returns true
-      File.stubs(:directory?).with('/mypath/root/etc').returns true
-      provider.expects(:zoneadm).with(:boot)
+      allow(Puppet::FileSystem).to receive(:exist?).with('/mypath/root/etc/sysidcfg').and_return true
+      allow(File).to receive(:directory?).with('/mypath/root/etc').and_return true
+      expect(provider).to receive(:zoneadm).with(:boot)
       provider.start
     end
 
     it 'requires path if sysidcfg is specified' do
-      resource.stubs(:[]).with(:path).returns nil
-      resource.stubs(:[]).with(:sysidcfg).returns 'dummy'
+      allow(resource).to receive(:[]).with(:path).and_return nil
+      allow(resource).to receive(:[]).with(:sysidcfg).and_return 'dummy'
       expect {
         provider.start
       }.to raise_error(Puppet::Error, %r{Path is required})
@@ -213,7 +214,7 @@ net:
   end
   context '#multi_conf' do
     it 'correctlies add and remove properties' do
-      provider.stubs(:properties).with.returns(ip: ['1.1.1.1', '2.2.2.2'])
+      allow(provider).to receive(:properties).and_return(ip: ['1.1.1.1', '2.2.2.2'])
       should = ['1.1.1.1', '3.3.3.3']
       p = proc do |a, str|
         case a
@@ -230,8 +231,8 @@ net:
         expect(provider.send(p.to_s + '_conf', 'dummy')).to match(v)
       end
       it "#{p}: should correctly set property string" do
-        provider.expects((p.to_s + '_conf').to_sym).returns('dummy')
-        provider.expects(:setconfig).with('dummy').returns('dummy2')
+        expect(provider).to receive((p.to_s + '_conf').to_sym).and_return('dummy')
+        expect(provider).to receive(:setconfig).with('dummy').and_return('dummy2')
         expect(provider.send(p.to_s + '=', 'dummy')).to eq('dummy2')
       end
     end

--- a/spec/unit/type/zone_spec.rb
+++ b/spec/unit/type/zone_spec.rb
@@ -27,7 +27,7 @@ describe Puppet::Type.type(:zone), type: :type do
   describe 'when trying to set a property that is empty' do
     it 'verifies that property.insync? of nil or :absent is true' do
       [inherit, ip, dataset].each do |prop|
-        prop.stubs(:should).returns []
+        allow(prop).to receive(:should).and_return []
       end
       expect([inherit, ip, dataset]).to all(be_insync(nil))
       expect([inherit, ip, dataset]).to all(be_insync(:absent))
@@ -36,7 +36,7 @@ describe Puppet::Type.type(:zone), type: :type do
   describe 'when trying to set a property that is non empty' do
     it 'verifies that property.insync? of nil or :absent is false' do
       [inherit, ip, dataset].each do |prop|
-        prop.stubs(:should).returns ['a', 'b']
+        allow(prop).to receive(:should).and_return ['a', 'b']
       end
       [inherit, ip, dataset].each do |prop|
         expect(prop).not_to be_insync(nil)
@@ -49,7 +49,7 @@ describe Puppet::Type.type(:zone), type: :type do
   describe 'when trying to set a property that is non empty' do
     it 'insync? should return true or false depending on the current value, and new value' do
       [inherit, ip, dataset].each do |prop|
-        prop.stubs(:should).returns ['a', 'b']
+        allow(prop).to receive(:should).and_return ['a', 'b']
       end
       expect([inherit, ip, dataset]).to all(be_insync(['b', 'a']))
       [inherit, ip, dataset].each do |prop|


### PR DESCRIPTION
To avoid having to update this everytime we release a new agent platform, it should be enough to specify the supported OS, without
specific versions. It is assumed that for each OS in metadata.json, the versions supported are the same as what the agent itself supports.