### PR TITLE
Update deprecated Beaker methods 

### DIFF
--- a/spec/acceptance/pending/dataset.rb
+++ b/spec/acceptance/pending/dataset.rb
@@ -55,7 +55,7 @@ agents.each do |agent|
   end
   step 'Zone: dataset - basic test, idempotency'
   apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>"tstpool/yy", path=>"/tstzones/mnt" }') do
-    assert_no_match(%r{dataset changed tstpool/xx to \['tstpool/yy'\]}, result.stdout, "err: #{agent}")
+    refute_match(%r{dataset changed tstpool/xx to \['tstpool/yy'\]}, result.stdout, "err: #{agent}")
   end
   step 'Zone: dataset - array test, should change to an array'
   apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>["tstpool/yy","tstpool/zz"], path=>"/tstzones/mnt" }') do

--- a/spec/acceptance/pending/dataset.rb
+++ b/spec/acceptance/pending/dataset.rb
@@ -12,19 +12,19 @@ extend Puppet::Acceptance::ZoneUtils
 
 def moresetup(agent)
   # This should fail if /tstzones already exists.
-  on agent, 'mkdir /tstzones'
-  on agent, 'mkfile 64m /tstzones/dsk'
-  on agent, 'zpool create tstpool /tstzones/dsk'
+  on(agent, 'mkdir /tstzones')
+  on(agent, 'mkfile 64m /tstzones/dsk')
+  on(agent, 'zpool create tstpool /tstzones/dsk')
 
-  on agent, 'zfs create tstpool/xx'
-  on agent, 'zfs create tstpool/yy'
-  on agent, 'zfs create tstpool/zz'
+  on(agent, 'zfs create tstpool/xx')
+  on(agent, 'zfs create tstpool/yy')
+  on(agent, 'zfs create tstpool/zz')
 end
 
 def moreclean(agent)
-  on agent, 'zfs destroy -r tstpool', acceptable_exit_codes: [0, 1]
-  on agent, 'zpool destroy tstpool', acceptable_exit_codes: [0, 1]
-  on agent, 'rm -f /tstzones/dsk'
+  on(agent, 'zfs destroy -r tstpool', acceptable_exit_codes: [0, 1])
+  on(agent, 'zpool destroy tstpool', acceptable_exit_codes: [0, 1])
+  on(agent, 'rm -f /tstzones/dsk')
 end
 
 teardown do
@@ -42,31 +42,31 @@ agents.each do |agent|
   #-----------------------------------
   step 'Zone: dataset - make it configured'
   # Make it configured
-  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, path=>"/tstzones/mnt" }') do
+  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, path=>"/tstzones/mnt" }') do |result|
     assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
   end
   step 'Zone: dataset - basic test, a single data set'
-  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>"tstpool/xx", path=>"/tstzones/mnt" }') do
+  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>"tstpool/xx", path=>"/tstzones/mnt" }') do |result|
     assert_match(%r{defined 'dataset' as .'tstpool.xx'.}, result.stdout, "err: #{agent}")
   end
   step 'Zone: dataset - basic test, a single data set should change to another'
-  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>"tstpool/yy", path=>"/tstzones/mnt" }') do
+  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>"tstpool/yy", path=>"/tstzones/mnt" }') do |result|
     assert_match(%r{dataset changed tstpool/xx to \['tstpool/yy'\]}, result.stdout, "err: #{agent}")
   end
   step 'Zone: dataset - basic test, idempotency'
-  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>"tstpool/yy", path=>"/tstzones/mnt" }') do
+  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>"tstpool/yy", path=>"/tstzones/mnt" }') do |result|
     refute_match(%r{dataset changed tstpool/xx to \['tstpool/yy'\]}, result.stdout, "err: #{agent}")
   end
   step 'Zone: dataset - array test, should change to an array'
-  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>["tstpool/yy","tstpool/zz"], path=>"/tstzones/mnt" }') do
+  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>["tstpool/yy","tstpool/zz"], path=>"/tstzones/mnt" }') do |result|
     assert_match(%r{dataset changed tstpool/yy to \['tstpool/yy', 'tstpool/zz'\]}, result.stdout, "err: #{agent}")
   end
   step 'Zone: dataset - array test, should change one single element'
-  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>["tstpool/xx","tstpool/zz"], path=>"/tstzones/mnt" }') do
+  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>["tstpool/xx","tstpool/zz"], path=>"/tstzones/mnt" }') do |result|
     assert_match(%r{dataset changed tstpool/yy,tstpool/zz to \['tstpool/xx', 'tstpool/zz'\]}, result.stdout, "err: #{agent}")
   end
   step 'Zone: dataset - array test, should remove elements'
-  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>[], path=>"/tstzones/mnt" }') do
+  apply_manifest_on(agent, 'zone {tstzone : ensure=>configured, dataset=>[], path=>"/tstzones/mnt" }') do |result|
     assert_match(%r{dataset changed tstpool/zz,tstpool/xx to \[\]}, result.stdout, "err: #{agent}")
   end
 end

--- a/spec/acceptance/pending/ticket_4840_should_create_zone_with_zpool.rb
+++ b/spec/acceptance/pending/ticket_4840_should_create_zone_with_zpool.rb
@@ -10,15 +10,15 @@ require 'puppet/acceptance/solaris_util'
 extend Puppet::Acceptance::ZoneUtils
 
 def poolsetup(agent)
-  on agent, 'mkdir /tstzones'
-  on agent, 'mkfile 2500m /tstzones/dsk'
-  on agent, 'zpool create tstpool /tstzones/dsk'
+  on(agent, 'mkdir /tstzones')
+  on(agent, 'mkfile 2500m /tstzones/dsk')
+  on(agent, 'zpool create tstpool /tstzones/dsk')
 end
 
 def poolclean(agent)
-  on agent, 'zfs destroy -r tstpool', acceptable_exit_codes: [0, 1]
-  on agent, 'zpool destroy tstpool', acceptable_exit_codes: [0, 1]
-  on agent, 'rm -rf /ztstpool', acceptable_exit_codes: [0, 1]
+  on(agent, 'zfs destroy -r tstpool', acceptable_exit_codes: [0, 1])
+  on(agent, 'zpool destroy tstpool', acceptable_exit_codes: [0, 1])
+  on(agent, 'rm -rf /ztstpool', acceptable_exit_codes: [0, 1])
 end
 
 teardown do
@@ -50,7 +50,7 @@ agents.each do |agent|
       iptype => exclusive,
       ip => net1,
       require => File["/ztstpool/mnt"],
-    })) do
+    })) do |result|
     assert_match(%r{ensure: created}, result.stdout, "err: #{agent}")
   end
 end

--- a/spec/acceptance/tests/zone_configured_spec.rb
+++ b/spec/acceptance/tests/zone_configured_spec.rb
@@ -27,7 +27,7 @@ RSpec.context 'zone manages path' do
 
         step 'Zone: steps - verify (create)'
         on(agent, 'zoneadm -z tstzone verify') do |result|
-          assert_no_match(%r{could not verify}, result.stdout, "err: #{agent}")
+          refute_match(%r{could not verify}, result.stdout, "err: #{agent}")
         end
 
         step 'Zone: steps - configured -> installed'

--- a/spec/acceptance/tests/zone_ensure_spec.rb
+++ b/spec/acceptance/tests/zone_ensure_spec.rb
@@ -43,7 +43,7 @@ RSpec.context 'Zone: should be created and removed' do
 
         # should be idempotent
         apply_manifest_on(agent, running_manifest) do |result|
-          assert_no_match(%r{created|changed|removed}, result.stdout, "err: #{agent}")
+          refute_match(%r{created|changed|removed}, result.stdout, "err: #{agent}")
         end
 
         step 'Zone: ensure can remove'
@@ -52,7 +52,7 @@ RSpec.context 'Zone: should be created and removed' do
           assert_match(%r{ensure: removed}, result.stdout, "err: #{agent}")
         end
         on(agent, 'zoneadm list -cp') do |result|
-          assert_no_match(%r{tstzone}, result.stdout, "err: #{agent}")
+          refute_match(%r{tstzone}, result.stdout, "err: #{agent}")
         end
       end
     end

--- a/spec/acceptance/tests/zone_ip_spec.rb
+++ b/spec/acceptance/tests/zone_ip_spec.rb
@@ -94,7 +94,7 @@ RSpec.context 'Zone:IP ip-type and ip configuration' do
             ip => ["ip.if.1:1.1.1.1", "ip.if.2:1.1.1.3"]
           }
           MANIFEST
-          assert_no_match(%r{ip changed}, result.stdout, "err: #{agent}")
+          refute_match(%r{ip changed}, result.stdout, "err: #{agent}")
         end
       end
     end

--- a/spec/acceptance/tests/zone_running_spec.rb
+++ b/spec/acceptance/tests/zone_running_spec.rb
@@ -36,7 +36,7 @@ RSpec.context 'zone manages path' do
 
         step 'Zone: statemachine - ensure zone is correct'
         on(agent, 'zoneadm -z tstzone verify') do |result|
-          assert_no_match(%r{could not verify}, result.stdout, "err: #{agent}")
+          refute_match(%r{could not verify}, result.stdout, "err: #{agent}")
         end
 
         step 'Zone: statemachine - ensure zone is running'


### PR DESCRIPTION
This PR updates several deprecated Beaker methods that were removed entirely in Beaker 5. This is in preparation for moving to Beaker 5 for tests.